### PR TITLE
Rewrite bulk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ SCRIPTS_DIR         ?= $(BASE_DIR)/scripts
 TESTS_DIR           ?= $(BASE_DIR)/tests
 
 CLIENT_VERSION      ?= 5
+DEBUG_LEVEL			?= debug
 
 SHELL               := /bin/bash
 SYSCTL              := $(shell which sysctl)
@@ -62,7 +63,7 @@ plugin_push:
 
 plugin_set:
 	@echo ""
-	docker plugin set $(PLUGIN_NAME):$(PLUGIN_TAG) LOG_LEVEL=debug
+	docker plugin set $(PLUGIN_NAME):$(PLUGIN_TAG) LOG_LEVEL=$(DEBUG_LEVEL)
 
 push: plugin_push
 

--- a/internal/pkg/errgroup/errgroup.go
+++ b/internal/pkg/errgroup/errgroup.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	ErrOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.ErrOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/pkg/docker/config.go
+++ b/pkg/docker/config.go
@@ -35,7 +35,7 @@ type Bulk struct {
 	actions       int
 	size          int
 	flushInterval time.Duration
-	stats         bool
+	// stats         bool
 }
 
 // Grok filter
@@ -60,9 +60,9 @@ func newConfiguration() Configuration {
 		Bulk: Bulk{
 			workers:       1,
 			actions:       100,
-			size:          5 << 20,
+			size:          5 << 20, // 5 MB = 0101 0000 0000 0000 0000 0000 = 5242880
 			flushInterval: 5 * time.Second,
-			stats:         false,
+			// stats:         false,
 		},
 
 		Grok: Grok{
@@ -183,12 +183,12 @@ func (c *Configuration) validateLogOpt(cfg map[string]string) error {
 				return fmt.Errorf("error: parsing elasticsearch-bulk-flush-interval: %q", err)
 			}
 			c.Bulk.flushInterval = flushInterval
-		case "elasticsearch-bulk-stats":
-			stats, err := strconv.ParseBool(v)
-			if err != nil {
-				return fmt.Errorf("error: parsing elasticsearch-bulk-stats: %q", err)
-			}
-			c.Bulk.stats = stats
+		// case "elasticsearch-bulk-stats":
+		// 	stats, err := strconv.ParseBool(v)
+		// 	if err != nil {
+		// 		return fmt.Errorf("error: parsing elasticsearch-bulk-stats: %q", err)
+		// 	}
+		// 	c.Bulk.stats = stats
 
 		case "grok-pattern":
 			c.grokPattern = v

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -32,6 +32,8 @@ type pipeline struct {
 	group    *errgroup.Group
 	inputCh  chan logdriver.LogEntry
 	outputCh chan LogMessage
+	commitCh chan struct{}
+	ticker   *time.Ticker
 }
 
 // Read reads messages from proto buffer
@@ -147,26 +149,13 @@ func (c *container) Parse(ctx context.Context, info logger.Info, fields, grokMat
 }
 
 // Log sends messages to Elasticsearch Bulk Service
-func (c *container) Log(ctx context.Context, workers, actions, size int, flushInterval time.Duration, stats bool, indexName, tzpe string) error {
+func (c *container) Log(ctx context.Context, workers int, indexName, tzpe string) error {
 
 	c.logger.Debug("starting pipeline: Log")
 
 	c.pipeline.group.Go(func() error {
-
-		err := c.esClient.NewBulkProcessorService(ctx, workers, actions, size, flushInterval, stats)
-		if err != nil {
-			c.logger.WithError(err).Error("could not create bulk processor")
-		}
-
 		defer func() {
-			if err := c.esClient.Flush(); err != nil {
-				c.logger.WithError(err).Error("could not flush queue")
-			}
-
-			if err := c.esClient.Close(); err != nil {
-				c.logger.WithError(err).Error("could not close client connection")
-			}
-			c.esClient.Stop()
+			close(c.pipeline.commitCh)
 		}()
 
 		for doc := range c.pipeline.outputCh {
@@ -174,6 +163,7 @@ func (c *container) Log(ctx context.Context, workers, actions, size int, flushIn
 			c.esClient.Add(indexName, tzpe, doc)
 
 			select {
+			case c.pipeline.commitCh <- struct{}{}:
 			case <-ctx.Done():
 				c.logger.WithError(ctx.Err()).Error("closing log pipeline")
 				return ctx.Err()
@@ -184,6 +174,85 @@ func (c *container) Log(ctx context.Context, workers, actions, size int, flushIn
 	})
 
 	return nil
+}
+
+// Log sends messages to Elasticsearch Bulk Service
+func (c *container) Commit(ctx context.Context, actions, size int, flushInterval time.Duration) error {
+
+	c.logger.Debug("starting pipeline: Commit")
+
+	c.pipeline.group.Go(func() error {
+
+		// err := c.esClient.NewBulkProcessorService(ctx, workers, actions, size, flushInterval, stats)
+
+		c.pipeline.ticker = time.NewTicker(flushInterval)
+
+		defer func() {
+			// if err := c.esClient.Flush(); err != nil {
+			// 	c.logger.WithError(err).Error("could not flush queue")
+			// }
+			// if err := c.esClient.Close(); err != nil {
+			// 	c.logger.WithError(err).Error("could not close client connection")
+			// }
+			c.logger.Debug("stopping ticker")
+			c.pipeline.ticker.Stop()
+
+			// commit any left messages in the queue
+			c.flush(ctx)
+
+			c.logger.Debug("stopping client")
+			c.esClient.Stop()
+		}()
+
+		for {
+			select {
+			case _, open := <-c.pipeline.commitCh:
+				if !open {
+					return nil
+				}
+				if c.esClient.CommitRequired(actions, size) {
+					c.commit(ctx)
+				}
+
+			case <-c.pipeline.ticker.C:
+				c.flush(ctx)
+
+			case <-ctx.Done():
+				c.logger.WithError(ctx.Err()).Error("closing log pipeline")
+				return ctx.Err()
+			}
+		}
+	})
+
+	return nil
+}
+
+func (c *container) flush(ctx context.Context) {
+	if c.esClient.NumberOfActions() > 0 {
+		c.commit(ctx)
+	}
+}
+
+func (c *container) commit(ctx context.Context) {
+
+	// c.logger.WithField("size", c.esClient.EstimatedSizeInBytes()).Debug("estimed size in bytes")
+	// c.logger.WithField("actions", c.esClient.NumberOfActions()).Debug("number of actions...")
+
+	bulkResponse, took, rerr, err := c.esClient.Do(ctx)
+	if err != nil || rerr {
+		c.logger.WithError(err).Error("could not commit all messages to elasticsearch")
+
+		// find out the reasons of the failure
+		if responses := c.esClient.Errors(bulkResponse); responses != nil {
+			for _, response := range responses {
+				for status, reason := range response {
+					c.logger.WithFields(log.Fields{"reason": reason, "status": status}).Info("reason and status")
+				}
+			}
+		}
+	}
+
+	c.logger.WithField("took", took).Debug("bulk response time")
 }
 
 // Stats shows metrics related to the bulk service

--- a/pkg/docker/driver.go
+++ b/pkg/docker/driver.go
@@ -12,7 +12,8 @@ import (
 	"github.com/robfig/cron"
 	"github.com/tonistiigi/fifo"
 
-	"golang.org/x/sync/errgroup"
+	// "golang.org/x/sync/errgroup"
+	"github.com/rchicoli/docker-log-elasticsearch/internal/pkg/errgroup"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types/plugins/logdriver"

--- a/pkg/elasticsearch/client.go
+++ b/pkg/elasticsearch/client.go
@@ -3,61 +3,68 @@ package elasticsearch
 import (
 	"context"
 	"fmt"
-	"time"
 
-	elasticv1 "github.com/rchicoli/docker-log-elasticsearch/pkg/elasticsearch/v1"
-	elasticv2 "github.com/rchicoli/docker-log-elasticsearch/pkg/elasticsearch/v2"
 	elasticv5 "github.com/rchicoli/docker-log-elasticsearch/pkg/elasticsearch/v5"
-	elasticv6 "github.com/rchicoli/docker-log-elasticsearch/pkg/elasticsearch/v6"
 )
 
 // Client ...
 type Client interface {
-	// Log(ctx context.Context, index, tzpe string, msg interface{}) error
+
+	// NewBulkProcessorService(ctx context.Context, workers, bulkActions, bulkSize int, flushInterval time.Duration, stats bool) error
+	// Stop the bulk processor and do some cleanup
+	// Close() error
+	// Flush() error
+
+	Add(index, tzpe string, msg interface{})
+	CommitRequired(actions int, bulkSize int) bool
+	Do(ctx context.Context) (interface{}, int, bool, error)
+	Errors(bulkResponse interface{}) []map[int]string
+	EstimatedSizeInBytes() int64
+	NumberOfActions() int
 
 	// Stop stops the background processes that the client is running,
 	// i.e. sniffing the cluster periodically and running health checks
 	// on the nodes.
 	Stop()
-
-	NewBulkProcessorService(ctx context.Context, workers, bulkActions, bulkSize int, flushInterval time.Duration, stats bool) error
-	Add(index, tzpe string, msg interface{}) error
-
-	// Stop the bulk processor and do some cleanup
-	Close() error
-	// Stats()
-
-	Flush() error
 }
 
 // NewClient ...
 func NewClient(version string, url, username, password string, timeout int, sniff bool, insecure bool) (Client, error) {
 	switch version {
-	case "1":
-		client, err := elasticv1.NewClient(url, username, password, timeout, sniff, insecure)
-		if err != nil {
-			return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
-		}
-		return client, nil
-	case "2":
-		client, err := elasticv2.NewClient(url, username, password, timeout, sniff, insecure)
-		if err != nil {
-			return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
-		}
-		return client, nil
+	// case "1":
+	// 	client, err := elasticv1.NewClient(url, username, password, timeout, sniff, insecure)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
+	// 	}
+	// 	return client, nil
+	// case "2":
+	// 	client, err := elasticv2.NewClient(url, username, password, timeout, sniff, insecure)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
+	// 	}
+	// 	return client, nil
 	case "5":
 		client, err := elasticv5.NewClient(url, username, password, timeout, sniff, insecure)
 		if err != nil {
 			return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
 		}
 		return client, nil
-	case "6":
-		client, err := elasticv6.NewClient(url, username, password, timeout, sniff, insecure)
-		if err != nil {
-			return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
-		}
-		return client, nil
+	// case "6":
+	// 	client, err := elasticv6.NewClient(url, username, password, timeout, sniff, insecure)
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("error: cannot create an elasticsearch client: %v", err)
+	// 	}
+	// 	return client, nil
 	default:
 		return nil, fmt.Errorf("error: elasticsearch version not supported: %v", version)
 	}
 }
+
+// func ParseBulkResponse(bulkResponse interface{}) string {
+// 	switch v := bulkResponse.(type) {
+// 	case elasticv5.Elasticsearch.BulkResponse:
+// 		return fmt.Sprint(v.Indexed)
+
+// 	}
+// 	return ""
+// }

--- a/pkg/elasticsearch/v5/elasticsearch.go
+++ b/pkg/elasticsearch/v5/elasticsearch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"golang.org/x/net/context"
 	"gopkg.in/olivere/elastic.v5"
@@ -14,9 +13,13 @@ import (
 // Elasticsearch ...
 type Elasticsearch struct {
 	*elastic.Client
-	*elastic.BulkProcessor
-	*elastic.BulkProcessorService
+	// *elastic.BulkProcessor
+	// *elastic.BulkProcessorService
+	*elastic.BulkService
+	*elastic.BulkResponse
 }
+
+// type BulkResponse = elastic.BulkResponse
 
 // NewClient ...
 func NewClient(address, username, password string, timeout int, sniff bool, insecure bool) (*Elasticsearch, error) {
@@ -43,8 +46,9 @@ func NewClient(address, username, password string, timeout int, sniff bool, inse
 		return nil, fmt.Errorf("elasticsearch: cannot connect to the endpoint: %s\n%v", url, err)
 	}
 	return &Elasticsearch{
-		Client:               c,
-		BulkProcessorService: c.BulkProcessor(),
+		Client: c,
+		// BulkProcessorService: c.BulkProcessor(),
+		BulkService: c.Bulk(),
 	}, nil
 }
 
@@ -56,39 +60,88 @@ func (e *Elasticsearch) Log(ctx context.Context, index, tzpe string, msg interfa
 	return nil
 }
 
-func (e *Elasticsearch) NewBulkProcessorService(ctx context.Context, workers, actions, size int, flushInterval time.Duration, stats bool) error {
-
-	p, err := e.BulkProcessorService.
-		Workers(workers).
-		BulkActions(actions).         // commit if # requests >= BulkSize
-		BulkSize(size).               // commit if size of requests >= 1 MB
-		FlushInterval(flushInterval). // commit every given interval
-		Stats(stats).                 // collect stats
-		// Backoff(backoff).
-		Do(ctx)
-	if err != nil {
-		return err
-	}
-
-	e.BulkProcessor = p
-
-	return nil
-}
-
-func (e *Elasticsearch) Add(index, tzpe string, msg interface{}) error {
-
+// Add adds bulkable requests, i.e. BulkIndexRequest, BulkUpdateRequest,
+// and/or BulkDeleteRequest.
+func (e *Elasticsearch) Add(index, tzpe string, msg interface{}) {
 	r := elastic.NewBulkIndexRequest().Index(index).Type(tzpe).Doc(msg)
-	e.BulkProcessor.Add(r)
-
-	return nil
+	e.BulkService.Add(r)
 }
 
-func (e *Elasticsearch) Close() error {
-	return e.BulkProcessor.Close()
+// CommitRequired returns true if the service has to commit its
+// bulk requests. This can be either because the number of actions
+// or the estimated size in bytes is larger than specified in the
+// BulkProcessorService.
+func (e *Elasticsearch) CommitRequired(actions int, bulkSize int) bool {
+	if e.BulkService.NumberOfActions() >= actions {
+		return true
+	}
+	if e.BulkService.EstimatedSizeInBytes() >= int64(bulkSize) {
+		return true
+	}
+	return false
 }
 
-func (e *Elasticsearch) Flush() error {
-	return e.BulkProcessor.Flush()
+// Do sends the batched requests to Elasticsearch. Note that, when successful,
+// you can reuse the BulkService for the next batch as the list of bulk
+// requests is cleared on success.
+// {
+//   "took":3,
+//   "errors":false,
+//   "items":[{
+//     "index":{
+//       "_index":"index1",
+//       "_type":"tweet",
+//       "_id":"1",
+//       "_version":3,
+//       "status":201
+//     }
+//   }
+// }
+func (e *Elasticsearch) Do(ctx context.Context) (interface{}, int, bool, error) {
+	bulkResponse, err := e.BulkService.Do(ctx)
+	return bulkResponse, bulkResponse.Took, bulkResponse.Errors, err
+}
+
+// Errors parses a BulkResponse and returns the reason of the failure requests
+// {
+// 	"error" : {
+// 	  "root_cause" : [
+// 		{
+// 		  "type" : "illegal_argument_exception",
+// 		  "reason" : "Failed to parse int parameter [size] with value [surprise_me]"
+// 		}
+// 	  ],
+// 	  "type" : "illegal_argument_exception",
+// 	  "reason" : "Failed to parse int parameter [size] with value [surprise_me]",
+// 	  "caused_by" : {
+// 		"type" : "number_format_exception",
+// 		"reason" : "For input string: \"surprise_me\""
+// 	  }
+// 	},
+// 	"status" : 400
+//   }
+func (e *Elasticsearch) Errors(bulkResponse interface{}) []map[int]string {
+	var reason []map[int]string
+	for _, item := range bulkResponse.(*elastic.BulkResponse).Items {
+		for _, result := range item {
+			reason = append(reason, map[int]string{
+				result.Status: result.Error.Reason,
+			})
+		}
+	}
+	return reason
+}
+
+// EstimatedSizeInBytes returns the estimated size of all bulkable
+// requests added via Add.
+func (e *Elasticsearch) EstimatedSizeInBytes() int64 {
+	return e.BulkService.EstimatedSizeInBytes()
+}
+
+// NumberOfActions returns the number of bulkable requests that need to
+// be sent to Elasticsearch on the next batch.
+func (e *Elasticsearch) NumberOfActions() int {
+	return e.BulkService.NumberOfActions()
 }
 
 // Stop stops the background processes that the client is running,
@@ -97,3 +150,30 @@ func (e *Elasticsearch) Flush() error {
 func (e *Elasticsearch) Stop() {
 	e.Client.Stop()
 }
+
+// func (e *Elasticsearch) NewBulkProcessorService(ctx context.Context, workers, actions, size int, flushInterval time.Duration, stats bool) error {
+// 	p, err := e.BulkProcessorService.
+// 		Workers(workers).
+// 		BulkActions(actions).         // commit if # requests >= BulkSize
+// 		BulkSize(size).               // commit if size of requests >= 1 MB
+// 		FlushInterval(flushInterval). // commit every given interval
+// 		Stats(stats).                 // collect stats
+// 		// Backoff(backoff).
+// 		Do(ctx)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	e.BulkProcessor = p
+// 	return nil
+// }
+// func (e *Elasticsearch) Add(index, tzpe string, msg interface{}) error {
+// 	r := elastic.NewBulkIndexRequest().Index(index).Type(tzpe).Doc(msg)
+// 	e.BulkProcessor.Add(r)
+// 	return nil
+// }
+// func (e *Elasticsearch) Close() error {
+// 	return e.BulkProcessor.Close()
+// }
+// func (e *Elasticsearch) Flush() error {
+// 	return e.BulkProcessor.Flush()
+// }


### PR DESCRIPTION
TODO:
 - add retry` RetryNotify(commitFunc, w.p.backoff, notifyFunc)`
 - implement functions for all other clients

Reasons of this MR
 - the BulkProcessorService does not report the error message, if one occurs.
 - simplify the things out, better overview what it is doing now.

Benchmark the changes from this custom Bulk and the BulkProcessor